### PR TITLE
Recognise gas-phase models and return None if any cell dim is 0

### DIFF
--- a/carmm/run/aims_calculator.py
+++ b/carmm/run/aims_calculator.py
@@ -179,6 +179,11 @@ def get_k_grid(model, sampling_density, surface=False, verbose=False):
         that have vacuum padding added.
     verbose: bool
         Flag turning print statements on/off
+
+    Returns:
+        float containing 3 integers: (kx, ky, kz)
+        or
+        None if a non-periodic model is presented
     """
     import math
     import numpy as np
@@ -186,6 +191,10 @@ def get_k_grid(model, sampling_density, surface=False, verbose=False):
     x = np.linalg.norm(model.get_cell()[0])
     y = np.linalg.norm(model.get_cell()[1])
     z = np.linalg.norm(model.get_cell()[2])
+
+    for i in [x, y, z]:
+        if i == 0:
+            return None
 
     k_x = math.ceil((1/sampling_density)*(1/x))
     k_y = math.ceil((1/sampling_density)*(1/y))

--- a/examples/run_k_grid.py
+++ b/examples/run_k_grid.py
@@ -6,6 +6,8 @@ Useful when running calculations for variable sizes of supercells (e.g. surfaces
 
 def test_run_k_grid():
     from carmm.run.aims_calculator import get_k_grid
+    from ase.build import molecule
+
 
     #### Traditional ASE functionality #####
     from data.model_gen import get_example_slab as slab
@@ -13,8 +15,9 @@ def test_run_k_grid():
     #########
     sampling_density = 0.02 # example value of sampling density /Angstrom
     k_grid = get_k_grid(slab, sampling_density, surface=True, verbose=True )
-    assert(k_grid[0] == 6)
-    assert(k_grid[1] == 6)
-    assert(k_grid[2] == 1)
+    assert k_grid[0] == 6
+    assert k_grid[1] == 6
+    assert k_grid[2] == 1
+    assert get_k_grid(molecule("CO2"), sampling_density) == None
 
 test_run_k_grid()

--- a/examples/run_k_grid.py
+++ b/examples/run_k_grid.py
@@ -17,7 +17,7 @@ def test_run_k_grid():
     k_grid = get_k_grid(slab, sampling_density, surface=True, verbose=True )
     assert k_grid[0] == 6
     assert k_grid[1] == 6
-    assert k_grid[2] == 1
+    assert k_grid == [6, 6, 1]
     assert get_k_grid(molecule("CO2"), sampling_density) == None
 
 test_run_k_grid()

--- a/examples/run_k_grid.py
+++ b/examples/run_k_grid.py
@@ -15,9 +15,7 @@ def test_run_k_grid():
     #########
     sampling_density = 0.02 # example value of sampling density /Angstrom
     k_grid = get_k_grid(slab, sampling_density, surface=True, verbose=True )
-    assert k_grid[0] == 6
-    assert k_grid[1] == 6
-    assert k_grid == [6, 6, 1]
+    assert k_grid == (6, 6, 1)
     assert get_k_grid(molecule("CO2"), sampling_density) == None
 
 test_run_k_grid()


### PR DESCRIPTION
This change will allow reusing the same calculator generator for any `dimension` when k_grid choice is dynamic. Currently presenting `get_k_grid` with a gas-phase model returns a division error. It will now return None instead, which can be safely passed to `k_grid` variable of the `get_aims_calculator`