### PR TITLE
Improve build.test.neb.bond_length_scan.dissociation code coverage

### DIFF
--- a/carmm/build/neb/WIP_neb_preselection.py
+++ b/carmm/build/neb/WIP_neb_preselection.py
@@ -1,3 +1,5 @@
+"""
+
 def pre_neb_aims(initial,
                  final,
                  hpc="hawk",
@@ -96,3 +98,5 @@ def pre_neb_aims(initial,
 
     else:
         print("No multiple extrema detected in the predicted Minimum Energy Path.")
+
+"""

--- a/examples/build_dissociation.py
+++ b/examples/build_dissociation.py
@@ -25,9 +25,6 @@ def test_dissociation():
     # Generate and optimise slab prior to dissociation
     slab = get_example_slab(adsorbate=True, type="2Cu")
 
-    # Set constraints to test functionality
-    slab.set_constraint([FixAtoms([atom.index for atom in slab if atom.tag > 1])])
-
     # move adsorbed Cu atoms (indices 18,19) away from each other
     # if z_bias is True, the distance increment is not exactly step_size value
     z_bias = True
@@ -38,6 +35,8 @@ def test_dissociation():
     assert(distance_list[0] - 3.099548 < 1e-5)
     assert(distance_list[9] - 4.815466 < 1e-5)
 
+    # Set constraints and remove z_bias to test functionality
+    slab.set_constraint([FixAtoms([atom.index for atom in slab if atom.tag > 1])])
     z_bias = False
     atoms_list, distance_list = dissociation(slab, 18, 19, step_size=0.2, n_steps=10, z_bias=z_bias, group_move=[19])
     assert(distance_list[0] - 3.084995 < 1e-5)

--- a/examples/build_dissociation.py
+++ b/examples/build_dissociation.py
@@ -20,23 +20,13 @@ personally so you can see how everything would work in a practical application
 def test_dissociation():
     from carmm.build.neb.bond_length_scan import dissociation
     from examples.data.model_gen import get_example_slab
-
-    from ase import Atoms
-    from ase.build import add_adsorbate
-
-    # Optimisation is disabled to ensure quick testing
-    # If you are running this to see the functionality, enable the optimisation
-    optimisation = False
-    if optimisation:
-        from ase.calculators.emt import EMT
-        from ase.optimize import BFGS
+    from ase.constraints import FixAtoms
 
     # Generate and optimise slab prior to dissociation
     slab = get_example_slab(adsorbate=True, type="2Cu")
 
-    if optimisation:
-        opt = BFGS(slab)
-        opt.run(fmax=0.05)
+    # Set constraints to test functionality
+    slab.set_constraint([FixAtoms([atom.index for atom in slab if atom.tag > 1])])
 
     # move adsorbed Cu atoms (indices 18,19) away from each other
     # if z_bias is True, the distance increment is not exactly step_size value
@@ -45,21 +35,28 @@ def test_dissociation():
 
     # Assertion tests - checking no one has broken the code.
     assert (len(distance_list) == len(atoms_list) == 10)
-    if z_bias:
-        assert(distance_list[0] - 3.099548 < 1e-5)
-        assert(distance_list[9] - 4.815466 < 1e-5)
-    else:
-        assert(distance_list[0] - 3.084995 < 1e-5)
-        assert(distance_list[9] - 4.884995 < 1e-5)
+    assert(distance_list[0] - 3.099548 < 1e-5)
+    assert(distance_list[9] - 4.815466 < 1e-5)
 
-    if optimisation:
-        for atoms in atoms_list:
-            atoms.calc = EMT()
-            opt = BFGS(atoms)
-            opt.run(fmax=0.05)
+    z_bias = False
+    atoms_list, distance_list = dissociation(slab, 18, 19, step_size=0.2, n_steps=10, z_bias=z_bias, group_move=[19])
+    assert(distance_list[0] - 3.084995 < 1e-5)
+    assert(distance_list[9] - 4.884995 < 1e-5)
 
-        from ase.visualize import view
-        view(atoms_list)
+    """
+    # Optimisation is disabled to ensure quick testing
+    # If you are running this to see the functionality, enable this code block
+    from ase.calculators.emt import EMT
+    from ase.optimize import BFGS
+    opt = BFGS(slab)
+    opt.run(fmax=0.05)
+    for atoms in atoms_list:
+        atoms.calc = EMT()
+        opt = BFGS(atoms)
+        opt.run(fmax=0.05)
 
+    from ase.visualize import view
+    view(atoms_list)
+    """
 
 test_dissociation()


### PR DESCRIPTION
Wrapped optimisation into a code block and tested the lack of z_bias explicitly with assertions