### PR TITLE
Revert "Update README.md"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![github](https://github.com/logsdail/carmm/actions/workflows/main.yml/badge.svg)](https://github.com/logsdail/carmm/actions)
 [![codecov.io](https://codecov.io/gh/logsdail/carmm/coverage.svg)](https://codecov.io/gh/logsdail/carmm)
 
-# Cardiff Multiscalar Modelling
+# Cardiff Molecular Modelling
 
 General scripts and software for everyday computational chemistry. Documentation of functionality is available at: https://logsdail.github.io/carmm/.
 


### PR DESCRIPTION
Reverts logsdail/carmm#159. Decided it is a poor change as no longer chemistry specific.