### PR TITLE
Enable task farming for falcon and isambard3

### DIFF
--- a/carmm/run/aims_calculator.py
+++ b/carmm/run/aims_calculator.py
@@ -148,8 +148,7 @@ def get_aims_and_sockets_calculator(dimensions,
     fhi_calc.parameters['use_pimd_wrapper']=[host, port]
     
     from carmm.utils.python_env_check import ase_env_check
-    from pathlib import Path
-    if ase_env_check('3.23.0') and fhi_calc.directory != Path("."):
+    if ase_env_check('3.23.0') and fhi_calc.directory not in [".", "./"]:
         # New way of building socket calculator in ASE
         # Enables launch client, so aims can write output files to a subdirectory
         # See ASE documentation at the example of Aims calculator "Communication with calculators over sockets"

--- a/carmm/run/aims_calculator.py
+++ b/carmm/run/aims_calculator.py
@@ -148,11 +148,8 @@ def get_aims_and_sockets_calculator(dimensions,
     fhi_calc.parameters['use_pimd_wrapper']=[host, port]
     
     from carmm.utils.python_env_check import ase_env_check
-    if ase_env_check('3.23.0') and fhi_calc.directory not in [".", "./"]:
-        # New way of building socket calculator in ASE
-        # Enables launch client, so aims can write output files to a subdirectory
-        # See ASE documentation at the example of Aims calculator "Communication with calculators over sockets"
-        # See source code here: `ase.calculators.CalculatorTemplate.socketio_calculator` <-- `ase.calculators.GenericFileIOCalculator.socketio` <-- `ase.calculators.aims`
+    from pathlib import Path
+    if fhi_calc.directory != Path(".") and ase_env_check('3.23.0'):
         socket_calc = fhi_calc.socketio(port=port)
     else:
         # Setup sockets calculator that "wraps" FHI-aims

--- a/carmm/run/aims_calculator.py
+++ b/carmm/run/aims_calculator.py
@@ -45,8 +45,6 @@ def get_aims_calculator(dimensions, relativistic=None, k_grid=None, xc="pbe", co
 
     if relativistic is None:
         parameter_dict['relativistic'] = ('atomic_zora', 'scalar')
-    else:
-        parameter_dict['relativistic'] = relativistic
 
     # Changing to check ASE version, as this determines behaviour of calculator
     from carmm.utils.python_env_check import ase_env_check
@@ -143,10 +141,18 @@ def get_aims_and_sockets_calculator(dimensions,
     fhi_calc = get_aims_calculator(dimensions, **kwargs)
     # Add in PIMD command to get sockets working
     fhi_calc.parameters['use_pimd_wrapper']=[host, port]
-
-    # Setup sockets calculator that "wraps" FHI-aims
-    from ase.calculators.socketio import SocketIOCalculator
-    socket_calc = SocketIOCalculator(fhi_calc, log=logfile, port=port)
+    
+    from carmm.utils.python_env_check import ase_env_check
+    if ase_env_check('3.23.0') and fhi_calc.directory not in [".", "./"]:
+        # New way of building socket calculator in ASE
+        # Enables launch client, so aims can write output files to a subdirectory
+        # See ASE documentation at the example of Aims calculator "Communication with calculators over sockets"
+        # See source code here: `ase.calculators.CalculatorTemplate.socketio_calculator` <-- `ase.calculators.GenericFileIOCalculator.socketio` <-- `ase.calculators.aims`
+        socket_calc = fhi_calc.socketio(port=port)
+    else:
+        # Setup sockets calculator that "wraps" FHI-aims
+        from ase.calculators.socketio import SocketIOCalculator
+        socket_calc = SocketIOCalculator(fhi_calc, log=logfile, port=port)
 
     if codata_warning:
         print("You are using i-Pi based socket connectivity between ASE and FHI-aims.")

--- a/carmm/run/aims_calculator.py
+++ b/carmm/run/aims_calculator.py
@@ -50,6 +50,8 @@ def get_aims_calculator(dimensions, relativistic=None, k_grid=None, xc="pbe", co
 
     if relativistic is None:
         parameter_dict['relativistic'] = ('atomic_zora', 'scalar')
+    else:
+        parameter_dict['relativistic'] = relativistic
 
     # Changing to check ASE version, as this determines behaviour of calculator
     from carmm.utils.python_env_check import ase_env_check

--- a/carmm/run/aims_calculator.py
+++ b/carmm/run/aims_calculator.py
@@ -143,7 +143,8 @@ def get_aims_and_sockets_calculator(dimensions,
     fhi_calc.parameters['use_pimd_wrapper']=[host, port]
     
     from carmm.utils.python_env_check import ase_env_check
-    if ase_env_check('3.23.0') and fhi_calc.directory not in [".", "./"]:
+    from pathlib import Path
+    if ase_env_check('3.23.0') and fhi_calc.directory != Path("."):
         # New way of building socket calculator in ASE
         # Enables launch client, so aims can write output files to a subdirectory
         # See ASE documentation at the example of Aims calculator "Communication with calculators over sockets"

--- a/carmm/run/aims_path.py
+++ b/carmm/run/aims_path.py
@@ -42,7 +42,7 @@ def set_aims_command(hpc='hawk', basis_set='light', defaults=2010, nodes_per_ins
     preamble = {
         "hawk": "time srun",
         "hawk-amd": "time srun",
-        "falcon": "time mpirun", 
+        "falcon": "time srun", 
         "isambard": "time aprun",
         "isambard3": "time srun",
         "archer2": "srun --cpu-bind=cores --distribution=block:block --hint=nomultithread",
@@ -89,7 +89,13 @@ def set_aims_command(hpc='hawk', basis_set='light', defaults=2010, nodes_per_ins
         # Todo: Add Isambard/Young as needed
         assert hpc in ["archer2", "hawk", "hawk-amd", "aws", "falcon", "isambard3"], \
             "Only ARCHER2, Hawk, AWS, Falcon, and Isambard3 supported for task-farming at the moment."
-
+        if hpc == "falcon":
+            print("""
+            Note: pointing manually to Slurm's PMI-1 or PMI-2 library is necessary for using srun with IPMI
+            Add a line like this 'export I_MPI_PMI_LIBRARY=/usr/lib64/libpmi.so' to your submission script 
+            if you see an error like this in your aims.out:
+            'MPI startup(): PMI server not found. Please set I_MPI_PMI_LIBRARY variable if it is not a singleton case.' 
+            See details in Slurm Documentation https://slurm.schedmd.com/mpi_guide.html#intel_mpi.""")
         if hpc == "aws":
             assert nodes_per_instance == 1, "FHI-aims does not run on more than one node on AWS at present."
 

--- a/carmm/run/aims_path.py
+++ b/carmm/run/aims_path.py
@@ -82,6 +82,20 @@ def set_aims_command(hpc='hawk', basis_set='light', defaults=2010, nodes_per_ins
 
     """Set the relevant environment variables based on HPC"""
     os.environ["AIMS_SPECIES_DIR"] = fhi_aims_directory[hpc] + species
+    
+    if hpc == "falcon":
+        if "I_MPI_PMI_LIBRARY" in os.environ:
+            print("PMI library is set. Carry on.")
+        else:
+            os.environ["I_MPI_PMI_LIBRARY"] = "/usr/lib64/libpmi.so"
+            print("Set PMI library path to ", os.environ["I_MPI_PMI_LIBRARY"])
+
+
+        #Note: pointing manually to Slurm's PMI-1 or PMI-2 library is necessary for using srun with IPMI
+        #if you see an error like this in your aims.out:
+        #'MPI startup(): PMI server not found. Please set I_MPI_PMI_LIBRARY variable if it is not a singleton case.' 
+        #See details in Slurm Documentation https://slurm.schedmd.com/mpi_guide.html#intel_mpi.
+    
 
     # Define the executable command
     if nodes_per_instance:
@@ -89,13 +103,6 @@ def set_aims_command(hpc='hawk', basis_set='light', defaults=2010, nodes_per_ins
         # Todo: Add Isambard/Young as needed
         assert hpc in ["archer2", "hawk", "hawk-amd", "aws", "falcon", "isambard3"], \
             "Only ARCHER2, Hawk, AWS, Falcon, and Isambard3 supported for task-farming at the moment."
-        if hpc == "falcon":
-            print("""
-            Note: pointing manually to Slurm's PMI-1 or PMI-2 library is necessary for using srun with IPMI
-            Add a line like this 'export I_MPI_PMI_LIBRARY=/usr/lib64/libpmi.so' to your submission script 
-            if you see an error like this in your aims.out:
-            'MPI startup(): PMI server not found. Please set I_MPI_PMI_LIBRARY variable if it is not a singleton case.' 
-            See details in Slurm Documentation https://slurm.schedmd.com/mpi_guide.html#intel_mpi.""")
         if hpc == "aws":
             assert nodes_per_instance == 1, "FHI-aims does not run on more than one node on AWS at present."
 

--- a/carmm/run/aims_path.py
+++ b/carmm/run/aims_path.py
@@ -131,6 +131,8 @@ def _get_cpu_command(hpc, nodes_per_instance=None):
         hpc_settings["hawk-amd"]["cpu_command_task_farming"] = f"--nodes={nodes_per_instance} --ntasks={int(hpc_settings['hawk-amd']['cpus_per_node'] * nodes_per_instance)} -d mpirun"
         hpc_settings["archer2"]["cpu_command_task_farming"] = f"--nodes={nodes_per_instance} --ntasks={int(hpc_settings['archer2']['cpus_per_node'] * nodes_per_instance)}"
         hpc_settings["aws"]["cpu_command_task_farming"] = f"--nodes={nodes_per_instance} --ntasks={int(hpc_settings['aws']['cpus_per_node'] * nodes_per_instance)}"
+        hpc_settings["falcon"]["cpu_command_task_farming"] = f"--nodes={nodes_per_instance} --ntasks={int(hpc_settings['falcon']['cpus_per_node'] * nodes_per_instance)}"
+        hpc_settings["isambard3"]["cpu_command_task_farming"] = f"--nodes={nodes_per_instance} --ntasks={int(hpc_settings['isambard3']['cpus_per_node'] * nodes_per_instance)}"
 
     # Check calculation effiency
     if hpc in ["hawk","hawk-amd"]:

--- a/carmm/run/aims_path.py
+++ b/carmm/run/aims_path.py
@@ -96,21 +96,6 @@ def set_aims_command(hpc='hawk', basis_set='light', defaults=2010, nodes_per_ins
         #'MPI startup(): PMI server not found. Please set I_MPI_PMI_LIBRARY variable if it is not a singleton case.' 
         #See details in Slurm Documentation https://slurm.schedmd.com/mpi_guide.html#intel_mpi.
     
-
-    if hpc == "falcon":
-        if "I_MPI_PMI_LIBRARY" in os.environ:
-            print("PMI library is set. Carry on.")
-        else:
-            os.environ["I_MPI_PMI_LIBRARY"] = "/usr/lib64/libpmi.so"
-            print("Set PMI library path to ", os.environ["I_MPI_PMI_LIBRARY"])
-
-
-        #Note: pointing manually to Slurm's PMI-1 or PMI-2 library is necessary for using srun with IPMI
-        #if you see an error like this in your aims.out:
-        #'MPI startup(): PMI server not found. Please set I_MPI_PMI_LIBRARY variable if it is not a singleton case.' 
-        #See details in Slurm Documentation https://slurm.schedmd.com/mpi_guide.html#intel_mpi.
-
-
     # Define the executable command
     if nodes_per_instance:
         # Check validity of task-farming setup before proceeding.

--- a/carmm/run/aims_path.py
+++ b/carmm/run/aims_path.py
@@ -87,8 +87,8 @@ def set_aims_command(hpc='hawk', basis_set='light', defaults=2010, nodes_per_ins
     if nodes_per_instance:
         # Check validity of task-farming setup before proceeding.
         # Todo: Add Isambard/Young as needed
-        assert hpc in ["archer2", "hawk", "hawk-amd", "aws"], \
-            "Only ARCHER2, Hawk and AWS supported for task-farming at the moment."
+        assert hpc in ["archer2", "hawk", "hawk-amd", "aws", "falcon", "isambard3"], \
+            "Only ARCHER2, Hawk, AWS, Falcon, and Isambard3 supported for task-farming at the moment."
 
         if hpc == "aws":
             assert nodes_per_instance == 1, "FHI-aims does not run on more than one node on AWS at present."

--- a/carmm/run/workflows/react.py
+++ b/carmm/run/workflows/react.py
@@ -795,7 +795,7 @@ def _calc_generator(params,
                                                              **params)
 
     fhi_calc.parameters['override_warning_libxc'] = 'True'
-
+    
     """Forces required for optimisation"""
     if not forces:
         fhi_calc.parameters = {k: v for k, v in fhi_calc.parameters.items() if k != 'compute_forces'}

--- a/carmm/run/workflows/react.py
+++ b/carmm/run/workflows/react.py
@@ -795,7 +795,7 @@ def _calc_generator(params,
                                                              **params)
 
     fhi_calc.parameters['override_warning_libxc'] = 'True'
-    
+
     """Forces required for optimisation"""
     if not forces:
         fhi_calc.parameters = {k: v for k, v in fhi_calc.parameters.items() if k != 'compute_forces'}

--- a/examples/run_aims.py
+++ b/examples/run_aims.py
@@ -53,8 +53,10 @@ def test_run_aims():
 
     for state in range(4):
         # fhi_calc = get_aims_calculator(state)
-        sockets_calc, fhi_calc = get_aims_and_sockets_calculator(dimensions=state, verbose=True)
-
+        if state != 3:
+            sockets_calc, fhi_calc = get_aims_and_sockets_calculator(dimensions=state, verbose=True)
+        else:
+            sockets_calc, fhi_calc = get_aims_and_sockets_calculator(dimensions=state, directory="childir", verbose=True)
         # These are unused - legacy? Remove if no issues.
         #default_params = {'relativistic': ('atomic_zora', 'scalar'),
         #                  'xc': 'pbe',
@@ -66,11 +68,15 @@ def test_run_aims():
         #    default_params['k_grid'] = True
 
         # Assertion test that the correct calculators and default arguments are being set
-        #if ase_env_check('3.22.0'):
-        #    assert (type(sockets_calc.launch_client.calc) == Aims)
-        #else:
-        #    assert (type(sockets_calc.calc) == Aims)
-        assert (type(sockets_calc.calc) == Aims)    
+        if ase_env_check('3.22.0'):
+            from pathlib import Path
+            if fhi_calc.directory != Path("."):
+                from ase.calculators.aims import AimsTemplate
+                assert (isinstance(sockets_calc.self, AimsTemplate))
+            else:
+                assert (type(sockets_calc.launch_client.calc) == Aims)
+        else:
+            assert (type(sockets_calc.calc) == Aims)
         
         params = getattr(fhi_calc, 'parameters')
         assert params['relativistic'] == ('atomic_zora', 'scalar')

--- a/examples/run_aims.py
+++ b/examples/run_aims.py
@@ -66,10 +66,10 @@ def test_run_aims():
         #    default_params['k_grid'] = True
 
         # Assertion test that the correct calculators and default arguments are being set
-        if ase_env_check('3.22.0'):
-            assert (type(sockets_calc.launch_client.calc) == Aims)
-        else:
+        if ase_env_check('3.23.0'):
             assert (type(sockets_calc.calc) == Aims)
+        else:
+            assert (type(sockets_calc.launch_client.calc) == Aims)
             
         params = getattr(fhi_calc, 'parameters')
         assert params['relativistic'] == ('atomic_zora', 'scalar')

--- a/examples/run_aims.py
+++ b/examples/run_aims.py
@@ -66,10 +66,10 @@ def test_run_aims():
         #    default_params['k_grid'] = True
 
         # Assertion test that the correct calculators and default arguments are being set
-        if ase_env_check('3.23.0'):
-            assert (type(sockets_calc.calc) == Aims)
-        else:
+        if ase_env_check('3.22.0'):
             assert (type(sockets_calc.launch_client.calc) == Aims)
+        else:
+            assert (type(sockets_calc.calc) == Aims)
             
         params = getattr(fhi_calc, 'parameters')
         assert params['relativistic'] == ('atomic_zora', 'scalar')

--- a/examples/run_aims.py
+++ b/examples/run_aims.py
@@ -66,11 +66,12 @@ def test_run_aims():
         #    default_params['k_grid'] = True
 
         # Assertion test that the correct calculators and default arguments are being set
-        if ase_env_check('3.22.0'):
-            assert (type(sockets_calc.launch_client.calc) == Aims)
-        else:
-            assert (type(sockets_calc.calc) == Aims)
-            
+        #if ase_env_check('3.22.0'):
+        #    assert (type(sockets_calc.launch_client.calc) == Aims)
+        #else:
+        #    assert (type(sockets_calc.calc) == Aims)
+        assert (type(sockets_calc.calc) == Aims)    
+        
         params = getattr(fhi_calc, 'parameters')
         assert params['relativistic'] == ('atomic_zora', 'scalar')
         assert params['xc'] == 'pbe'

--- a/examples/run_aims.py
+++ b/examples/run_aims.py
@@ -23,7 +23,7 @@ def test_run_aims():
     expected_paths_taskfarm = {
         'hawk':      "time srun --nodes=1 --ntasks=40 -d mpirun /apps/local/projects/scw1057/software/fhi-aims/bin/aims.$VERSION.scalapack.mpi.x",
         'hawk-amd':  'time srun --nodes=1 --ntasks=64 -d mpirun /apps/local/projects/scw1057/software/fhi-aims/bin/aims.$VERSION.scalapack.mpi.x',
-        'falcon': 'time srun --nodes=1 --ntasks=192 /shared/home2/app_shared/SCWF00007/software/fhi-aims/release/$VERSION/bin/aims.$VERSION.scalapack.mpi.x'
+        'falcon': 'time srun --nodes=1 --ntasks=192 /shared/home2/app_shared/SCWF00007/software/fhi-aims/release/$VERSION/bin/aims.$VERSION.scalapack.mpi.x',
         'isambard':  '',
         'isambard3': 'time srun --nodes=1 --ntasks=144 /projects/c5b/software/fhi-aims/release/$VERSION/bin/aims.$VERSION.scalapack.mpi.x',
         'archer2':   'srun --cpu-bind=cores --distribution=block:block --hint=nomultithread --nodes=1 --ntasks=128 /work/e05/e05-files-log/shared/software/fhi-aims/bin/aims.$VERSION.scalapack.mpi.x',

--- a/examples/run_aims.py
+++ b/examples/run_aims.py
@@ -23,8 +23,9 @@ def test_run_aims():
     expected_paths_taskfarm = {
         'hawk':      "time srun --nodes=1 --ntasks=40 -d mpirun /apps/local/projects/scw1057/software/fhi-aims/bin/aims.$VERSION.scalapack.mpi.x",
         'hawk-amd':  'time srun --nodes=1 --ntasks=64 -d mpirun /apps/local/projects/scw1057/software/fhi-aims/bin/aims.$VERSION.scalapack.mpi.x',
+        'falcon': 'time srun --nodes=1 --ntasks=192 /shared/home2/app_shared/SCWF00007/software/fhi-aims/release/$VERSION/bin/aims.$VERSION.scalapack.mpi.x'
         'isambard':  '',
-        'isambard3': '',
+        'isambard3': 'time srun --nodes=1 --ntasks=144 /projects/c5b/software/fhi-aims/release/$VERSION/bin/aims.$VERSION.scalapack.mpi.x',
         'archer2':   'srun --cpu-bind=cores --distribution=block:block --hint=nomultithread --nodes=1 --ntasks=128 /work/e05/e05-files-log/shared/software/fhi-aims/bin/aims.$VERSION.scalapack.mpi.x',
         'young':     '',
         'aws':       'time srun --mpi=pmi2 --hint=nomultithread --distribution=block:block --nodes=1 --ntasks=72 apptainer exec /shared/logsdail_group/sing/mkl_aims_2.sif bash /shared/logsdail_group/sing/sing_fhiaims_script.sh $@'
@@ -41,7 +42,7 @@ def test_run_aims():
             hpc], f"Path incorrect on {hpc}: {expected_paths[hpc]}\n" \
                   f"Currently: {os.environ['ASE_AIMS_COMMAND']}"
 
-        if hpc in ["hawk", 'hawk-amd', 'archer2', 'aws']:
+        if hpc in ["hawk", 'hawk-amd', 'archer2', 'aws', 'falcon', 'isambard3']:
             set_aims_command(hpc, nodes_per_instance=1)
             assert os.environ['ASE_AIMS_COMMAND'] == expected_paths_taskfarm[
                 hpc], f"Path incorrect on {hpc}: {expected_paths_taskfarm[hpc]}\n" \

--- a/examples/run_aims.py
+++ b/examples/run_aims.py
@@ -71,9 +71,10 @@ def test_run_aims():
         # Assertion test that the correct calculators and default arguments are being set
         if ase_env_check('3.22.0'):
             from pathlib import Path
-            if fhi_calc.directory != Path("."):
+            if fhi_calc.directory != Path(".") and ase_env_check('3.23.0'):
                 from ase.calculators.aims import AimsTemplate
-                assert (isinstance(sockets_calc.self, AimsTemplate))
+                # Neither sockets_calc or sockets_calc.launch_client connects to Aims calculator directly with fhi_calc.socketio()
+                assert (sockets_calc.launch_client.__module__ == "ase.calculators.genericfileio")
             else:
                 assert (type(sockets_calc.launch_client.calc) == Aims)
         else:


### PR DESCRIPTION
A first attempt to make task farming work on falcon and isambard3, as discussed here #231.

These code passed a simple test case I used, but more testing may be needed.

Major changes are listed here.

1. Update the way of building socket calculator for ase >=3.23.0 if a directory other than `cwd` is required.
2. Use `srun` on falcon to enable task farming. Manually adding `export I_MPI_PMI_LIBRARY=/usr/lib64/libpmi.so` to submission script is required though.


Note on the memory arguments for task farming on falcon:

I tested adding this `--mem=$SLURM_MEM_PER_NODE` to the cpu commands, and it fails with "invaild --mem argument" error.
Letting Slurm quietly bind cpu to memory before task runs (default behaviour) worked for my test.

