### PR TITLE
Specify phonopy version in main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         python -m pip install --upgrade ase-gpatom
         python -m pip install --upgrade pytest
         python -m pip install --upgrade pytest-cov
-        python -m pip install --upgrade "pymatgen<=2026.3.23, pymatgen-core<2026.4.16"
+        python -m pip install --upgrade "pymatgen<=2026.3.23", "pymatgen-core<2026.4.16"
         python -m pip install --upgrade "phonopy<4.0.0"
         python -m pip install --upgrade mace-torch
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
         python -m pip install --upgrade pytest
         python -m pip install --upgrade pytest-cov
         python -m pip install --upgrade pymatgen
-        python -m pip install --upgrade phonopy
+        python -m pip install --upgrade phonopy<=3.5.1
         python -m pip install --upgrade mace-torch
         
         # Debug

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
         python -m pip install --upgrade pytest
         python -m pip install --upgrade pytest-cov
         python -m pip install --upgrade pymatgen
-        python -m pip install --upgrade phonopy<=3.5.1
+        python -m pip install --upgrade phonopy<4.0.0
         python -m pip install --upgrade mace-torch
         
         # Debug

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,9 +51,8 @@ jobs:
         python -m pip install --upgrade ase-gpatom
         python -m pip install --upgrade pytest
         python -m pip install --upgrade pytest-cov
-        #python -m pip install --upgrade "pymatgen<=2026.3.23", "pymatgen-core<2026.4.16"
-        python -m pip install --upgrade "pymatgen<2026.3.23"
-        python -m pip install --upgrade "phonopy<4.0.0"
+        python -m pip install --upgrade "pymatgen<=2025.10.7"  # Before pymatgen-core dependency introduced (which requires python>=3.10)
+        python -m pip install --upgrade "phonopy<4.0.0"  # phonopy>=4.0.0 changes produced output files (gives file not found error for 'thermal_properties.yaml')
         python -m pip install --upgrade mace-torch
         
         # Debug

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         python -m pip install --upgrade ase-gpatom
         python -m pip install --upgrade pytest
         python -m pip install --upgrade pytest-cov
-        python -m pip install --upgrade "pymatgen<=2026.3.23"
+        python -m pip install --upgrade "pymatgen<=2026.3.23, pymatgen-core<2026.4.16"
         python -m pip install --upgrade "phonopy<4.0.0"
         python -m pip install --upgrade mace-torch
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
         python -m pip install --upgrade pytest
         python -m pip install --upgrade pytest-cov
         python -m pip install --upgrade pymatgen
-        python -m pip install --upgrade phonopy>=2.45.0,<4.0.0
+        python -m pip install --upgrade "phonopy<4.0.0"
         python -m pip install --upgrade mace-torch
         
         # Debug

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         python -m pip install --upgrade ase-gpatom
         python -m pip install --upgrade pytest
         python -m pip install --upgrade pytest-cov
-        python -m pip install --upgrade pymatgen
+        python -m pip install --upgrade "pymatgen<=2026.3.23"
         python -m pip install --upgrade "phonopy<4.0.0"
         python -m pip install --upgrade mace-torch
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
         python -m pip install --upgrade pytest
         python -m pip install --upgrade pytest-cov
         python -m pip install --upgrade pymatgen
-        python -m pip install --upgrade phonopy<4.0.0
+        python -m pip install --upgrade phonopy>=2.45.0,<4.0.0
         python -m pip install --upgrade mace-torch
         
         # Debug

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,8 @@ jobs:
         python -m pip install --upgrade ase-gpatom
         python -m pip install --upgrade pytest
         python -m pip install --upgrade pytest-cov
-        python -m pip install --upgrade "pymatgen<=2026.3.23", "pymatgen-core<2026.4.16"
+        #python -m pip install --upgrade "pymatgen<=2026.3.23", "pymatgen-core<2026.4.16"
+        python -m pip install --upgrade "pymatgen<2026.3.23"
         python -m pip install --upgrade "phonopy<4.0.0"
         python -m pip install --upgrade mace-torch
         


### PR DESCRIPTION
Persistent phonopy error in CI-tests depends on version:
ERROR analyse_phonon.py - Exception: The file 'thermal_properties.yaml' not found. Make sure you are providing the correct file name to the thermal_file parameter in the function

Phonopy 3.2.0 + Python 3.10/3.13 = Success
Phonopy 2.45.1 + Python 3.9 = Success
Phonopy 2.45.1 + Python 3.10/3.13 = Fail (Phonopy version not available in these python versions)
Phonopy 4.1.0 + Python 3.10/3.13 = Fail (Above persistent error)