### PR TITLE
Pin phonopy version to 3.5.1 in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,8 @@ jobs:
         python -m pip install --upgrade pytest
         python -m pip install --upgrade pytest-cov
         python -m pip install --upgrade "pymatgen<=2025.10.7"  # Before pymatgen-core dependency introduced (which requires python>=3.10)
-        python -m pip install --upgrade "phonopy=3.5.1"  # phonopy>=4.0.0 changes produced output files (gives file not found error for 'thermal_properties.yaml')
+        #python -m pip install --upgrade "phonopy<4.0.0"  # phonopy>=4.0.0 changes produced output files (gives file not found error for 'thermal_properties.yaml')
+        python -m pip install --upgrade "phonopy==3.5.1"  # For Python 3.9, it tries to install 2.45.1 which fails.
         python -m pip install --upgrade mace-torch
         
         # Debug

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
         python -m pip install --upgrade pytest
         python -m pip install --upgrade pytest-cov
         python -m pip install --upgrade "pymatgen<=2025.10.7"  # Before pymatgen-core dependency introduced (which requires python>=3.10)
-        python -m pip install --upgrade "phonopy<4.0.0"  # phonopy>=4.0.0 changes produced output files (gives file not found error for 'thermal_properties.yaml')
+        python -m pip install --upgrade "phonopy=3.5.1"  # phonopy>=4.0.0 changes produced output files (gives file not found error for 'thermal_properties.yaml')
         python -m pip install --upgrade mace-torch
         
         # Debug


### PR DESCRIPTION
Seems to no longer build for 2.45.1, which was being initiated for Python3.9